### PR TITLE
Wifi singleton

### DIFF
--- a/ParticleConnect/Classes/Helpers/UI.swift
+++ b/ParticleConnect/Classes/Helpers/UI.swift
@@ -25,4 +25,13 @@ class UI {
         alertController.addAction(submitAction)
         viewController.present(alertController, animated: true, completion: nil)
     }
+    
+    static func presentBasicAlert(`in` viewController: UIViewController, message: String) {
+        let action = UIAlertAction(title: "Damn", style: .default)
+        let alert = UIAlertController(title: "Error", message: message, preferredStyle: .alert)
+            
+        alert.addAction(action)
+        
+        viewController.present(alert, animated: true, completion: nil)
+    }
 }

--- a/ParticleConnect/Classes/Models/Wifi.swift
+++ b/ParticleConnect/Classes/Models/Wifi.swift
@@ -9,12 +9,17 @@ import Foundation
 import UIKit
 import SystemConfiguration.CaptiveNetwork
 
+extension Notification.Name {
+    public static let ConnectedToParticleDevice = Notification.Name("ConnectedToParticleDevice")
+}
+
 public class Wifi {
     
     // MARK: - Public
     
-    public init(_ connectionBlock: @escaping (UIApplicationState) -> Void) {
-        self.onConnectionHandler = connectionBlock
+    static let shared = Wifi()
+    
+    public init() {
         NotificationCenter.default.addObserver(self, selector: #selector(startMonitoringConnectionInForeground), name: NSNotification.Name.UIApplicationDidBecomeActive, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(startMonitoringConnectionInBackground), name: NSNotification.Name.UIApplicationDidEnterBackground, object: nil)
     }
@@ -75,7 +80,6 @@ public class Wifi {
     static let foregroundTimerInterval = 1.0
     static let backgroundTimerInterval = 1.0
     
-    private let onConnectionHandler: (UIApplicationState) -> Void
     private var foregroundTimer: Timer?
     private var backgroundTimer: Timer?
     
@@ -123,7 +127,7 @@ public class Wifi {
         
         stopMonitoringConnectionInBackground()
         
-        onConnectionHandler(state)
+        NotificationCenter.default.post(name: Notification.Name.ConnectedToParticleDevice, object: state)
     }
     
     @objc private func checkDeviceWifiConnection(timer: Timer) {
@@ -133,7 +137,7 @@ public class Wifi {
         guard state == .active,
             Wifi.isDeviceConnected(.photon) else { return }
         
-        onConnectionHandler(state)
+        NotificationCenter.default.post(name: Notification.Name.ConnectedToParticleDevice, object: state)
     }
     
     

--- a/ParticleConnect/Classes/ViewControllers/FindDeviceViewController.swift
+++ b/ParticleConnect/Classes/ViewControllers/FindDeviceViewController.swift
@@ -12,6 +12,8 @@ public class FindDeviceViewController: UIViewController {
     
     let loaderView = LoaderView(frame: .zero)
     
+    let thing: LoadingRepresentable & UIView = LoaderView(frame: .zero)
+    
     fileprivate var communicationManager: DeviceCommunicationManager?
     private var retryCount = 0
     
@@ -69,7 +71,6 @@ public class FindDeviceViewController: UIViewController {
         
         UNUserNotificationCenter.current().add(request, withCompletionHandler: nil)
     }
-    
     
     // MARK: Navigation
     

--- a/ParticleConnect/Classes/ViewControllers/FindDeviceViewController.swift
+++ b/ParticleConnect/Classes/ViewControllers/FindDeviceViewController.swift
@@ -108,7 +108,7 @@ public class FindDeviceViewController: UIViewController {
                 self?.communicationManager = nil
                 completion(value.deviceId)
             case .failure(let error):
-                print(error)
+                self?.communicationManager = nil
                 if error == ConnectionError.timeout {
                     if self != nil && !self!.retry {
                         self?.retry = true
@@ -135,6 +135,7 @@ public class FindDeviceViewController: UIViewController {
                 print("public key: \(result)")
                 completion()
             case .failure:
+                self?.communicationManager = nil
                 guard let viewController = self else { return }
                 UI.presentBasicAlert(in: viewController, message: "Could not get the public key")
             }

--- a/ParticleConnect/Classes/Views/LoaderView.swift
+++ b/ParticleConnect/Classes/Views/LoaderView.swift
@@ -8,10 +8,65 @@
 
 import UIKit
 
-internal class LoaderView: UIView {
-    let activityIndicator = UIActivityIndicatorView(activityIndicatorStyle: .whiteLarge)
+protocol LoadingRepresentable {
+    func show(_ text: String)
+    func hide(_ text: String?)
+    func setText(_ text: String)
+}
+
+extension LoadingRepresentable where Self: UIView {
+    func hide(_ text: String? = nil) {}
+}
+
+internal class LoaderView: UIView, LoadingRepresentable {
     
-    let textLabel: UILabel = {
+    // MARK: - Public
+    
+    func show(_ text: String) {
+        textLabel.text = text
+        activityIndicator.startAnimating()
+        
+        UIView.animate(withDuration: 0.3) {
+            self.alpha = 1.0
+        }
+    }
+    
+    func hide(_ text: String? = nil) {
+        let fadeOut = {
+            UIView.animate(withDuration: 0.3, animations: {
+                self.alpha = 0.0
+            }) { _ in
+                self.activityIndicator.stopAnimating()
+            }
+        }
+        
+        if let message = text {
+            setText(message)
+            DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+                fadeOut()
+            }
+        } else {
+            fadeOut()
+        }
+        
+    }
+    
+    func setText(_ text: String) {
+        UIView.animate(withDuration: 0.3, animations: {
+            self.textLabel.alpha = 0.0
+        }) { _ in
+            self.textLabel.text = text
+            UIView.animate(withDuration: 0.3, animations: {
+                self.textLabel.alpha = 1.0
+            })
+        }
+    }
+
+    // MARK - Private
+    
+    private let activityIndicator = UIActivityIndicatorView(activityIndicatorStyle: .whiteLarge)
+    
+    private let textLabel: UILabel = {
         let label = UILabel(frame: .zero)
         label.font = UIFont.systemFont(ofSize: 14, weight: .medium)
         label.textColor = .white
@@ -20,7 +75,7 @@ internal class LoaderView: UIView {
         return label
     }()
     
-    let stackView: UIStackView = {
+    private let stackView: UIStackView = {
         let sv = UIStackView()
         sv.alignment = .fill
         sv.axis = .vertical
@@ -79,43 +134,4 @@ internal class LoaderView: UIView {
         textLabel.translatesAutoresizingMaskIntoConstraints = false
     }
     
-    func show(_ initialText: String) {
-        textLabel.text = initialText
-        activityIndicator.startAnimating()
-            
-        UIView.animate(withDuration: 0.3) {
-            self.alpha = 1.0
-        }
-    }
-    
-    func hide(_ optionalMessage: String? = nil) {
-        let fadeOut = {
-            UIView.animate(withDuration: 0.3, animations: {
-                self.alpha = 0.0
-            }) { _ in
-                self.activityIndicator.stopAnimating()
-            }
-        }
-        
-        if let message = optionalMessage {
-            setText(message)
-            DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
-                fadeOut()
-            }
-        } else {
-            fadeOut()
-        }
-
-    }
-    
-    func setText(_ text: String) {
-        UIView.animate(withDuration: 0.3, animations: {
-            self.textLabel.alpha = 0.0
-        }) { _ in
-            self.textLabel.text = text
-            UIView.animate(withDuration: 0.3, animations: {
-                self.textLabel.alpha = 1.0
-            })
-        }
-    }
 }


### PR DESCRIPTION
This PR introduces a singleton object for `Wifi`. 

Due to the nature of this framework, we need a persistent object that is monitoring network connections. Up until this point, the `Wifi` class was primarily concerned with checking for a connection between the phone and the particle hardware, however, we also want to know when our phone is back on the original WiFi or 3G/LTE network. This responsibility is currently managed in `SelectNetworkViewController`, which is definitely incorrect. Moving this responsibility to `Wifi` may not be the perfect solution, but it certainly makes more sense than `SelectNetworkViewController`